### PR TITLE
Handle exit code sent by service

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -65,8 +65,8 @@ function invoke(socket, token, args, text) {
   });
   socket.on('end', () => {
     if (buf) {
-      if (buf === '# exit 1') {
-        process.exitCode = 1;
+      if (buf.startsWith('# exit ')) {
+        process.exitCode = Number(buf.substring(7));
       } else {
         out.write(buf);
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,9 +6,9 @@ const crypto = require('crypto');
 const portfile = require('./portfile');
 const service = require(process.env.CORE_D_SERVICE);
 
-function fail(con, message) {
+function fail(con, message, exitCode = 1) {
   try {
-    con.end(`${message}\n# exit 1`);
+    con.end(`${message}\n# exit ${exitCode}`);
   } catch (ignore) {
     // Nothing we can do
   }
@@ -62,7 +62,9 @@ exports.start = function () {
 
     const handleResult = (err, result) => {
       if (err) {
-        fail(con, String(err));
+        const exitCode = typeof err === 'object'
+              && err.exitCode ? err.exitCode : 1;
+        fail(con, String(err), exitCode);
         return;
       }
       con.write(result);

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -267,6 +267,16 @@ describe('client', () => {
       assert.equals(process.exitCode, 1);
     });
 
+    it('sets exitCode to code specified in response', () => {
+      invoke();
+
+      socket.emit('data', 'Some response\n# exit 99');
+      socket.emit('end');
+
+      assert.calledOnceWith(out.write, 'Some response\n');
+      assert.equals(process.exitCode, 99);
+    });
+
     it('streams lines', () => {
       invoke();
 

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -245,6 +245,19 @@ describe('server', () => {
       assert.calledOnceWith(connection.end, 'Error: Whatever\n# exit 1');
     });
 
+    it('handles error response from service with specified exit code', () => {
+      sinon.replace(fs, 'stat', sinon.fake.yields(new Error()));
+      const serviceError = new Error('Whatever');
+      serviceError.exitCode = 2;
+      sinon.replace(service, 'invoke',
+        sinon.fake.yields(serviceError));
+      start();
+
+      request(connection, `${token} ${JSON.stringify(json)}`);
+
+      assert.calledOnceWith(connection.end, 'Error: Whatever\n# exit 2');
+    });
+
     it('does not throw if connection died after exception from service', () => {
       sinon.replace(fs, 'stat', sinon.fake.yields(new Error()));
       sinon.replace(service, 'invoke',


### PR DESCRIPTION
Please see the relevant eslint_d [issue](https://github.com/mantoni/eslint_d.js/issues/155) and [pull request](https://github.com/mantoni/eslint_d.js/pull/156). 

Like I mentioned in the linked issue, the goal was to enable the service to send an arbitrary exit code with the downside of having to use regex matching, though I'm not sure how much of a real-world performance penalty this might incur. 

Handling just `# exit 2` would solve my use case, but it might be a little restrictive for other services, so please let me know your thoughts. 