### PR TITLE
XDG Compliance

### DIFF
--- a/lib/portfile.js
+++ b/lib/portfile.js
@@ -3,9 +3,8 @@
 
 const fs = require('fs');
 
-const temp_env = process.platform === 'win32' ? 'TEMP' : 'XDG_RUNTIME_DIR';
 const home_env = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
-const data_dir = process.env[temp_env] || process.env[home_env];
+const data_dir = process.env.XDG_RUNTIME_DIR || process.env[home_env];
 const data_file = `${data_dir}/${process.env.CORE_D_DOTFILE}`;
 
 exports.write = function (port, token) {

--- a/lib/portfile.js
+++ b/lib/portfile.js
@@ -3,8 +3,10 @@
 
 const fs = require('fs');
 
+const temp_env = process.platform === 'win32' ? 'TEMP' : 'XDG_RUNTIME_DIR';
 const home_env = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
-const data_file = `${process.env[home_env]}/${process.env.CORE_D_DOTFILE}`;
+const data_dir = process.env[temp_env] || process.env[home_env];
+const data_file = `${data_dir}/${process.env.CORE_D_DOTFILE}`;
 
 exports.write = function (port, token) {
   fs.writeFileSync(data_file, `${port} ${token}`);

--- a/test/portfile-test.js
+++ b/test/portfile-test.js
@@ -6,9 +6,8 @@ const crypto = require('crypto');
 const { assert, refute, sinon } = require('@sinonjs/referee-sinon');
 const portfile = require('../lib/portfile');
 
-const temp_env = process.platform === 'win32' ? 'TEMP' : 'XDG_RUNTIME_DIR';
 const home_env = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
-const data_dir = process.env[temp_env] || process.env[home_env];
+const data_dir = process.env.XDG_RUNTIME_DIR || process.env[home_env];
 const data_file = `${data_dir}/.core_d`;
 const token = crypto.randomBytes(8).toString('hex');
 

--- a/test/portfile-test.js
+++ b/test/portfile-test.js
@@ -6,8 +6,10 @@ const crypto = require('crypto');
 const { assert, refute, sinon } = require('@sinonjs/referee-sinon');
 const portfile = require('../lib/portfile');
 
+const temp_env = process.platform === 'win32' ? 'TEMP' : 'XDG_RUNTIME_DIR';
 const home_env = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
-const data_file = `${process.env[home_env]}/.core_d`;
+const data_dir = process.env[temp_env] || process.env[home_env];
+const data_file = `${data_dir}/.core_d`;
 const token = crypto.randomBytes(8).toString('hex');
 
 describe('portfile', () => {


### PR DESCRIPTION
I'm not entirely sure if this is the best way to implement this, TBH. Can't really test things on Windows that easily.

This changes the code to use `$XDG_RUNTIME_DIR/$CORE_D_DOTFILE` on Linux, and falls back upon `$HOME/$CORE_D_DOTFILE`.
On Windows, it uses `$TEMP/$CORE_D_DOTFILE`, and falls back upon `$USERPROFILE/$CORE_D_DOTFILE`.

I noticed that Node has [`os.tmpdir`](https://nodejs.org/api/os.html#os_os_tmpdir) and [`os.homedir`](https://nodejs.org/api/os.html#os_os_homedir), which might be simpler than checking the environment variables. There'd still need to be an XDG check included with that, but it might be able to remove the `home_env` variable.
That having been said, I have no idea if Windows path separators would affect this.

I'm also not sure if there's an appropriate default on macOS. As it stands, I think it would always end up using `$HOME/$CORE_D_DOTFILE`.

And I'm not sure whether this should use a subdirectory of the temp dir, or the temp dir directly.

I'm fine with changing anything in this.

Fixes #13, https://github.com/mantoni/eslint_d.js/issues/158 (eventually)