### PR TITLE
BREAKING: Remove broken package manager file checks

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require('fs');
 const net = require('net');
 const crypto = require('crypto');
 const portfile = require('./portfile');
@@ -40,14 +39,6 @@ function parseData(data) {
   };
 }
 
-const stat_files = [
-  'package.json',
-  'package-lock.json',
-  'npm-shrinkwrap.json',
-  'yarn.lock',
-  'pnpm-lock.yaml'
-];
-
 exports.start = function () {
 
   const token = crypto.randomBytes(8).toString('hex');
@@ -56,32 +47,7 @@ exports.start = function () {
   const server = net.createServer({
     allowHalfOpen: true
   }, (con) => {
-    let latch = stat_files.length + 1;
-    const hash = crypto.createHash('md5');
     let data = '';
-
-    const handleResult = (err, result) => {
-      if (err) {
-        const exitCode = typeof err === 'object'
-              && err.exitCode ? err.exitCode : 1;
-        fail(con, String(err), exitCode);
-        return;
-      }
-      con.write(result);
-      con.end();
-    };
-
-    const decrementLatch = () => {
-      if (--latch === 0) {
-        const { cwd, args, text } = parseData(data);
-        try {
-          service.invoke(cwd, args, text, hash.digest('base64'), handleResult);
-        } catch (e) {
-          fail(con, String(e));
-        }
-      }
-    };
-
     con.on('data', (chunk) => {
       data += chunk;
     });
@@ -111,17 +77,24 @@ exports.start = function () {
         }
         return;
       }
-      decrementLatch();
-    });
-    const onReadFile = (err, content) => {
-      if (!err) {
-        hash.update(content);
+
+      const { cwd, args, text } = parseData(data);
+      try {
+        service.invoke(cwd, args, text, (err, result) => {
+          if (err) {
+            const exitCode = typeof err === 'object' && err.exitCode
+              ? err.exitCode
+              : 1;
+            fail(con, String(err), exitCode);
+            return;
+          }
+          con.write(result);
+          con.end();
+        });
+      } catch (e) {
+        fail(con, String(e));
       }
-      decrementLatch();
-    };
-    for (const stat_file of stat_files) {
-      fs.readFile(stat_file, onReadFile);
-    }
+    });
   });
 
   server.on('connection', (con) => {


### PR DESCRIPTION
The package manager file checks where always checking the files in the directory where the service was started. It should run the checks in the passed in `cwd` instead. This was never working as intended.

Additionally, the change introduce in #20 (and mantoni/eslint_d.js#190) to check the contents of the files instead of the mtime could product different hashes on subsequent calls, even if the file content did not actually change. This could happen in the callbacks on `fs.readFile` calls where invoked in different order than a previous call (see mantoni/eslint_d.js#198).

This change removes the broken file check feature entirely. The feature will be implemented in `eslint_d` instead.

__BREAKING:__ The service API contract changed as it does not receive the `hash` parameter anymore.